### PR TITLE
Fix task management, various cleanup

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -6,3 +6,5 @@
 --wrapcollections before-first
 --wrapconditions before-first
 --wrapparameters before-first
+
+--header "{file}\nThis Source Code Form is subject to the terms of the Mozilla Public\nLicense, v. 2.0. If a copy of the MPL was not distributed with this\nfile, You can obtain one at https://mozilla.org/MPL/2.0/."

--- a/Sources/Logging.swift
+++ b/Sources/Logging.swift
@@ -3,6 +3,7 @@ import Puppy
 
 func configureLogging(_ level: LogLevel) throws -> Puppy {
     // TODO: logfile per project
+    // And also make this nicer for unit tests
     let logFormat = LogFormatter()
     let fileLogger = try FileLogger(
         "com.peregrine",

--- a/Sources/Logging.swift
+++ b/Sources/Logging.swift
@@ -1,3 +1,8 @@
+// Logging.swift
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Puppy
 

--- a/Sources/Output.swift
+++ b/Sources/Output.swift
@@ -1,3 +1,8 @@
+// Output.swift
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import ArgumentParser
 
 func print(_ str: String, terminator: String = "\n", _ color: TextColor) {

--- a/Sources/Peregrine.swift
+++ b/Sources/Peregrine.swift
@@ -82,7 +82,7 @@ extension Peregrine {
             }
             let testOptions = TestOptions(
                 toolchainPath: options.toolchain,
-                packagePath: options.path,
+                packagePath: URL(fileURLWithPath: options.path, isDirectory: true).path,
                 plaintextOutput: options.plaintextOutput,
                 quietOutput: options.quiet,
                 additionalSwiftFlags: swiftFlags,

--- a/Sources/Peregrine.swift
+++ b/Sources/Peregrine.swift
@@ -1,3 +1,8 @@
+// Peregrine.swift
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import ArgumentParser
 import Foundation
 import Puppy
@@ -95,7 +100,6 @@ extension Peregrine {
                 let testResults = try await testRunner.runTests(tests: tests)
                 try testRunner.output(results: testResults)
             }
-
 
             // only cleanup on fully successful run
             try cleanupLogFile(logger: logger)

--- a/Sources/TestRunner.swift
+++ b/Sources/TestRunner.swift
@@ -1,3 +1,8 @@
+// TestRunner.swift
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import Foundation
 import Puppy
 import SwiftCommand

--- a/Sources/TestRunner.swift
+++ b/Sources/TestRunner.swift
@@ -94,23 +94,22 @@ class PeregrineRunner: TestRunner {
             throw TestParseError.notSwiftPackage
         }
 
-        let buildingTask = Task {
-            if !options.quietOutput {
+        let buildingTask = Task(priority: .utility) {
+            if !self.options.quietOutput {
                 let spinnerStates = ["/", "-", #"\"#, "|"]
                 var iteration = 0
-                while true {
-                    logger.trace("Rotating spinner...")
-                    if Task.isCancelled { return }
+                repeat {
+                    self.logger.trace("Rotating spinner...")
                     print(
-                        options.symbolOutput
+                        self.options.symbolOutput
                             .getSymbol(.Build) + " Building... \(spinnerStates[iteration % spinnerStates.count])",
                         terminator: "\r",
                         .CyanBold
                     )
-                    try await Task.sleep(for: .milliseconds(100.0))
                     fflush(nil)
                     iteration += 1
-                }
+                    try? await Task.sleep(for: .milliseconds(100.0))
+                } while !Task.isCancelled
             }
         }
 

--- a/Tests/PeregrineTests/PeregrineTests.swift
+++ b/Tests/PeregrineTests/PeregrineTests.swift
@@ -5,7 +5,7 @@ class PeregrineTests: XCTestCase {
     var runner: PeregrineRunner!
     let testPackagePath = "TestPackage/"
 
-    override func setUp() {
+    override func setUpWithError() throws {
         let testOptions = TestOptions(
             toolchainPath: nil,
             packagePath: testPackagePath,
@@ -19,7 +19,7 @@ class PeregrineTests: XCTestCase {
             )
         )
 
-        runner = PeregrineRunner(options: testOptions)
+        runner = try PeregrineRunner(options: testOptions, logger: configureLogging(.debug))
     }
 
     func testParseList() async throws {

--- a/Tests/PeregrineTests/PeregrineTests.swift
+++ b/Tests/PeregrineTests/PeregrineTests.swift
@@ -1,3 +1,8 @@
+// PeregrineTests.swift
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 @testable import peregrine
 import XCTest
 


### PR DESCRIPTION
- Spinner task should now properly run with a priority
- Spinner task repeat cleaned up
- Spinner task should properly cancel in most/all cases
- Added MPL headers to all source & format config
- Fixed a bug where paths would get mangled because I wasn't using absolute paths when trimming my output like a dumdum

resolves #6 #7 #10